### PR TITLE
Bump slop version to use with new version of pry

### DIFF
--- a/magic_cloud.gemspec
+++ b/magic_cloud.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = '2.2.2'
   
   s.add_dependency 'rmagick'
-  s.add_dependency 'slop', '~> 3.0.0' # for bin/magic_cloud options parsing
+  s.add_dependency 'slop', '~> 3.0' # for bin/magic_cloud options parsing
   
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
@zverok Could you take a look on this change? 
I checked, it works well with slop 3.6.0. I need need to use this gem in my app, so could you make it release? 

If you couldn't maintenance this gem more, you could let me handle. Or allow me fork to another gem to make it update. 

Waiting for your answer. 
Thanks :)