### PR TITLE
canvas: premature return in draw_text if text is empty.

### DIFF
--- a/lib/magic_cloud/canvas.rb
+++ b/lib/magic_cloud/canvas.rb
@@ -17,6 +17,8 @@ module MagicCloud
     RADIANS = Math::PI / 180
 
     def draw_text(text, options = {})
+      return nil if text.empty?
+
       draw = Magick::Draw.new # FIXME: is it necessary every time?
 
       x = options.fetch(:x, 0)


### PR DESCRIPTION
Otherwise a crash will be observed:

```
/var/lib/gems/2.3.0/gems/rmagick-2.16.0/lib/rmagick_internal.rb:617:in `text': missing text argument (ArgumentError)
	from /projects/magic_cloud/lib/magic_cloud/canvas.rb:36:in `draw_text'
	from /projects/magic_cloud/lib/magic_cloud/word.rb:19:in `draw'
	from /projects/magic_cloud/lib/magic_cloud/spriter.rb:35:in `make_sprite'
	from /projects/magic_cloud/lib/magic_cloud/spriter.rb:20:in `block in make_sprites!'
	from /projects/magic_cloud/lib/magic_cloud/spriter.rb:19:in `each'
	from /projects/magic_cloud/lib/magic_cloud/spriter.rb:19:in `make_sprites!'
	from /projects/magic_cloud/lib/magic_cloud/cloud.rb:41:in `draw'
	from ./bin/magic_cloud:72:in `<main>'
```